### PR TITLE
Fix deviation from Avro specification in Array and Map types.

### DIFF
--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -169,8 +169,10 @@ defmodule AvroEx.Decode do
   def do_decode(%Array{items: item_schema}, %Context{} = context, data) when is_binary(data) do
     {count, buffer} = do_decode(%Primitive{type: :long}, context, data)
 
+    times = if count > 0, do: 1..count, else: []
+
     {decoded_items, rest} =
-      Enum.reduce(1..count, {[], buffer}, fn _, {decoded_items, buffer} ->
+      Enum.reduce(times, {[], buffer}, fn _, {decoded_items, buffer} ->
         {decoded_item, buffer} = do_decode(item_schema, context, buffer)
         {[decoded_item | decoded_items], buffer}
       end)

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -157,12 +157,15 @@ defmodule AvroEx.Encode do
       size ->
         acc = do_encode(%Primitive{type: :long}, context, size)
 
-        Enum.reduce(map, acc, fn {k, v}, acc ->
-          key = do_encode(%Primitive{type: :string}, context, k)
-          value = do_encode(values, context, v)
+        encoded_map =
+          Enum.reduce(map, acc, fn {k, v}, acc ->
+            key = do_encode(%Primitive{type: :string}, context, k)
+            value = do_encode(values, context, v)
 
-          acc <> key <> value
-        end)
+            acc <> key <> value
+          end)
+
+        encoded_map <> <<0>>
     end
   end
 
@@ -174,11 +177,14 @@ defmodule AvroEx.Encode do
       size ->
         acc = do_encode(%Primitive{type: :long}, context, size)
 
-        Enum.reduce(data, acc, fn v, acc ->
-          value = do_encode(items, context, v)
+        encoded_array =
+          Enum.reduce(data, acc, fn v, acc ->
+            value = do_encode(items, context, v)
 
-          acc <> value
-        end)
+            acc <> value
+          end)
+
+        encoded_array <> <<0>>
     end
   end
 

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -161,6 +161,41 @@ defmodule AvroEx.Decode.Test do
       {:ok, encoded_sha} = AvroEx.encode(schema, sha)
       assert {:ok, ^sha} = @test_module.decode(schema, encoded_sha)
     end
+
+    test "record with empty array of records" do
+      {:ok, schema} = AvroEx.parse_schema(~S(
+        {
+          "type": "record",
+          "name": "User",
+          "fields": [
+            {
+              "name": "friends",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "Friend",
+                  "fields": [
+                    {
+                      "name": "userId",
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "username",
+              "type": "string"
+            }
+          ]
+        }
+      ))
+
+      {:ok, encoded} = AvroEx.encode(schema, %{"friends" => [], "username" => "iamauser"})
+
+      assert {:ok, %{"friends" => [], "username" => "iamauser"}} = @test_module.decode(schema, encoded)
+    end
   end
 
   describe "decode logical types" do

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -276,72 +276,26 @@ defmodule AvroEx.Encode.Test do
   end
 
   describe "encode (map)" do
-    test "encodes the count as a long" do
+    test "properly encodes the length, key-value pairs, and terminal byte" do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
-      {:ok, long_schema} = AvroEx.parse_schema(~S("long"))
-      {:ok, expected_count} = @test_module.encode(long_schema, 3)
-
-      {:ok, <<actual_count::8, _rest::binary>>} =
-        @test_module.encode(schema, %{"value1" => 1, "value2" => 2, "value3" => 3})
-
-      assert expected_count == <<actual_count>>
-    end
-
-    test "encodes the key-value pair correctly" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
-      {:ok, string_schema} = AvroEx.parse_schema(~S("string"))
-      {:ok, int_schema} = AvroEx.parse_schema(~S("int"))
-      {:ok, expected_key} = @test_module.encode(string_schema, "value1")
-      {:ok, expected_value} = @test_module.encode(int_schema, 1)
-      {:ok, <<_count::8, rest::binary>>} = @test_module.encode(schema, %{"value1" => 1})
-
-      assert rest == expected_key <> expected_value
+      assert {:ok, <<2, 12, 118, 97, 108, 117, 101, 49, 2, 0>>} = @test_module.encode(schema, %{"value1" => 1})
     end
 
     test "encodes an empty map" do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
-      {:ok, long_schema} = AvroEx.parse_schema(~S("long"))
-      {:ok, expected_count} = @test_module.encode(long_schema, 0)
-
-      assert {:ok, <<actual_count::8>>} = @test_module.encode(schema, %{})
-      assert expected_count == <<actual_count>>
+      assert {:ok, <<0>>} = @test_module.encode(schema, %{})
     end
   end
 
   describe "encode (array)" do
-    test "encodes the count as a long" do
+    test "properly encodes an array with length, items, and terminal byte" do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
-      {:ok, long_schema} = AvroEx.parse_schema(~S("long"))
-      {:ok, expected_count} = @test_module.encode(long_schema, 3)
-
-      {:ok, <<actual_count::8, _rest::binary>>} = @test_module.encode(schema, [1, 2, 3])
-
-      assert expected_count == <<actual_count>>
-    end
-
-    test "encodes the remaining values" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
-      {:ok, int_schema} = AvroEx.parse_schema(~S("int"))
-      items = [1, 2, 3]
-
-      ints =
-        items
-        |> Enum.map(fn item ->
-          {:ok, v} = @test_module.encode(int_schema, item)
-          v
-        end)
-        |> Enum.join()
-
-      assert {:ok, <<_count::8>> <> ^ints} = @test_module.encode(schema, items)
+      assert {:ok, <<6, 2, 4, 6, 0>>} = @test_module.encode(schema, [1, 2, 3])
     end
 
     test "encodes an empty array" do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
-      {:ok, long_schema} = AvroEx.parse_schema(~S("long"))
-      {:ok, expected_count} = @test_module.encode(long_schema, 0)
-
-      assert {:ok, <<actual_count::8>>} = @test_module.encode(schema, [])
-      assert expected_count == <<actual_count>>
+      assert {:ok, <<0>>} = @test_module.encode(schema, [])
     end
   end
 


### PR DESCRIPTION
Howdy @CJPoll, this is a follow up on #15 but includes a fixes for a couple of issues we discovered. The most pressing problem at hand: failure to encode data according to the Avro spec.

http://avro.apache.org/docs/current/spec.html#binary_encode_complex

> Arrays are encoded as a series of blocks. Each block consists of a long count value, followed by that many array items. __A block with count zero indicates the end of the array.__ Each item is encoded per the array's item schema.

> an array containing the items 3 and 27 could be encoded as the long value 2 (encoded as hex 04) followed by long values 3 and 27 (encoded as hex 06 36) terminated by zero:
> 04 06 36 00

> Maps are encoded as a series of blocks. Each block consists of a long count value, followed by that many key/value pairs. __A block with count zero indicates the end of the map.__ Each item is encoded per the map's value schema.

(emphasis mine)

We noticed this when we tried to decode data we'd encoded with AvroEx with `bin/kafka-avro-console-consumer`.

Separately of this we've also discovered the need to support the Confluent wire format. Would you be open to an enhancement PR that would add support for that? https://docs.confluent.io/5.0.0/schema-registry/docs/serializer-formatter.html#wire-format